### PR TITLE
Bruke pakkeversjon 20250707134156-167dc41

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -35,7 +35,7 @@ dependencies {
     val opensearchVersion = "1.8.1"
     val opensearchTestcontainersVersion = "2.1.3"
     val testcontainersVersion = "1.21.3"
-    val navnoSearchCommonVersion = "20250718115138-bda7702"
+    val navnoSearchCommonVersion = "20250707134156-167dc41"
     val kotestVersion = "5.9.1"
     val mockkVersion = "1.14.5"
 


### PR DESCRIPTION
Feil pakkeversjon ble tatt i bruk etter den dependabot-bump.